### PR TITLE
closes #63 sidekiqの起動チェック間隔を短くする

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -32,7 +32,7 @@ every 1.day, :at => '23:00 pm' do
   rake "image:clean"
 end
 
-every '*/1 * * * *' do
+every '*/3 * * * *' do
   rails4_runner "MonitorSidekiq.check_and_restart"
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -32,7 +32,7 @@ every 1.day, :at => '23:00 pm' do
   rake "image:clean"
 end
 
-every '*/5 * * * *' do
+every '*/1 * * * *' do
   rails4_runner "MonitorSidekiq.check_and_restart"
 end
 


### PR DESCRIPTION
どうやらuserstreamのリスタート用に5分にしたっぽい．
一斉restartは一分以上かかる可能性があるため．

それにしても長いので3分くらいにしよう．