### PR TITLE
Revert "closes #81 capistrano-sidekiq/monitを導入し旧再起動スクリプトを削除"

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -24,7 +24,6 @@ require 'capistrano/rails/migrations'
 # require 'capistrano/passenger'
 require 'capistrano3/unicorn'
 require 'whenever/capistrano'
-require "capistrano/sidekiq/monit"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,5 @@ group :development do
   gem 'capistrano-rbenv'
   gem 'capistrano-bundler'
   gem 'capistrano3-unicorn'
-  gem 'capistrano-sidekiq'
   gem 'web-console', '~> 2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,9 +81,6 @@ GEM
     capistrano-rbenv (2.0.4)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
-    capistrano-sidekiq (0.5.4)
-      capistrano
-      sidekiq (>= 3.4)
     capistrano3-unicorn (0.2.1)
       capistrano (~> 3.1, >= 3.1.0)
     capybara (2.7.0)
@@ -383,7 +380,6 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rails
   capistrano-rbenv
-  capistrano-sidekiq
   capistrano3-unicorn
   capybara
   carrierwave
@@ -437,4 +433,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.13.6
+   1.11.2

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module WhalebirdServer
     # -- all .rb files in that directory are automatically loaded.
 
     config.autoload_paths << "#{config.root}/lib/extras"
+    config.autoload_paths << "#{config.root}/lib/scripts"
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -25,10 +25,15 @@ set :output, {:error => 'log/crontab.err.log', :standard => 'log/crontab.log'}
 # ジョブの実行環境の指定
 set :environment, :production
 env :PATH, ENV['PATH']
+job_type :rails4_runner, "cd :path && bin/rails runner -e :environment :task :output"
 
 
 every 1.day, :at => '23:00 pm' do
   rake "image:clean"
+end
+
+every '*/5 * * * *' do
+  rails4_runner "MonitorSidekiq.check_and_restart"
 end
 
 every '21 21 * * *' do

--- a/lib/scripts/monitor_sidekiq.rb
+++ b/lib/scripts/monitor_sidekiq.rb
@@ -1,0 +1,30 @@
+# restart if sidekiq has died.
+#
+# run every 1 minute.
+# */1 * * * * /usr/bin/ruby [path]/restart_sidekiq.rb
+
+class MonitorSidekiq
+  def self.check_and_restart
+    log_file = "#{Rails.root}/log/restart_sidekiq.log"
+    result = `ps aux | grep sidekiq | grep -v 'grep'`
+
+    process_found = false
+    result.split("\n").each{|line|
+      next if !line.include?('sidekiq 4.1.1')
+
+      process_found = true
+      break
+    }
+
+    if process_found
+      log = Time.now.to_s + ' sidekiq has lived.'
+      #`echo "#{log}" >>"#{log_file}"`
+      exit
+    end
+
+    restart_result = `cd #{Rails.root} && bundle exec sidekiq -d -C config/sidekiq.yml -e production`
+    log = Time.now.to_s + ' sidekiq is restarted.'
+    `echo "#{log}" >>"#{log_file}"`
+    `echo "#{restart_result}" >>"#{log_file}"`
+  end
+end


### PR DESCRIPTION
Reverts h3poteto/whalebird.server#82

monitの再起動だと，userstream:restartとの噛み合わせが良くない．
結局，cronでの自前再起動のほうがレースコンディションのコントロールが楽になる．